### PR TITLE
PMDのルール変更

### DIFF
--- a/Forest_Program/pmd/pmd-rules.xml
+++ b/Forest_Program/pmd/pmd-rules.xml
@@ -27,7 +27,7 @@
     <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseAfterAnnotation" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseBeforeAnnotation" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseTestAnnotation" /> -->
-    <rule ref="category/java/bestpractices.xml/JUnitAssertionsShouldIncludeMessage" />
+    <!--rule ref="category/java/bestpractices.xml/JUnitAssertionsShouldIncludeMessage" /> -->
     <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts">
         <properties>
             <property name="maximumAsserts" value="3" />


### PR DESCRIPTION
# やった内容
・EmptyStatementNotInLoopを削除しました
・MethodNamingConventionsを削除しました
・JUnitAssertionsShouldIncludeMessageを削除しました
# 確認して欲しい事
・pmdでForestModel等を確認した際にEmptyStatementNotInLoopが出ないか
・pmdでForestDataTest等を確認した際MethodNamingConventionsとJUnitAssertionsShouldIncludeMessageが出ないか
・他に変更点が無いか